### PR TITLE
Add Make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+all: build
+
+preview:
+	bundle exec jekyll clean
+	bundle exec jekyll serve --future --drafts --unpublished --incremental
+
+build:
+	bundle exec jekyll clean
+	bundle exec jekyll build --future --drafts --unpublished


### PR DESCRIPTION
I'm used to using `make` to build my static sites (it's what we do for optech and review club), so I'm adding a makefile to this project. Call `make preview` to preview the site.

Two make targets:
- `make build` builds the site using `jekyll build`
- `make preview` builds and serves the site using `jekyll serve`

`make all` and `make` alias to `make build`.

