### PR TITLE
Add placeholder page for socratic 100

### DIFF
--- a/_posts/2020-01-09-socratic-seminar-100.md
+++ b/_posts/2020-01-09-socratic-seminar-100.md
@@ -1,0 +1,7 @@
+---
+layout: post
+type: socratic
+title: "Socratic Seminar 100"
+---
+
+To suggest a topic for bitdevs Socratic seminar 100, please comment on [https://github.com/BitDevsNYC/BitDevsNYC.github.io/pull/38](https://github.com/BitDevsNYC/BitDevsNYC.github.io/pull/38).


### PR DESCRIPTION
Adds a placeholder page for socratic 100. I propose that we merge this now, and then replace it with the final page when we have the content for the meetup.

@btsea - I think you're going to add a form where people can submit suggestions for content. For now, I've just added a link to the github PR where people can comment.