### PR TITLE
Presenter Guidelines

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -3,4 +3,6 @@ tagline: 'BitDevs is a community for those interested in discussing and particip
 
 menu:
   - {name: 'About', url: '/about'}
+  - {name: 'Events', url: '/events'}
+  - {name: 'Blog', url: '/blog'}
   - {name: 'Meetup', url: 'https://www.meetup.com/BitDevsNYC/', external: true}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -1,0 +1,20 @@
+---
+layout: default
+---
+
+<section>
+  <div class="Blog">
+    <h1 class="Post-title">{{ page.title }}</h1>
+    <div class="Post-info">
+      <span>{{ page.date | date_to_string }}</span>
+      {% if page.meetup %}
+        <span>
+          <a href="{{ page.meetup }}" target="_blank" rel="noopener nofollow">
+            Link to Meetup
+          </a>
+        </span>
+      {% endif %}
+    </div>
+    <div class="Post-content">{{ content }}</div>
+  </div>
+</section>

--- a/_posts/2020-02-12-presenter-guidelines.md
+++ b/_posts/2020-02-12-presenter-guidelines.md
@@ -1,0 +1,38 @@
+---
+layout: blog
+type: blog
+title: "Presenter Guidelines"
+permalink: /presenter-guidelines/
+---
+
+We regularly host guest speakers at our Socratic Seminar events to talk about
+technical contributions to the community. The talks  are _not_ for promoting
+products or services.
+
+We have some guidelines to make sure that the talk is useful and relevant for
+our members:
+
+- You **must not** solicit investment from our audience in any way. 
+- All presentations are capped at 15 minutes, including question time.
+- The content of your presentation must be directly relevant to a technical
+  audience that is interested in:
+  - How the Bitcoin protocol works.
+  - Innovations that improve the inner workings of the Bitcoin protocol.
+  - Projects that strengthen the ecosystem (e.g. make it easier/safer to
+    interact with, tooling for developers, etc.).
+- Your project must be:
+  - Technically innovative (rehashing of existing tech in a new product would
+    not qualify, unless the implementation is demonstrably novel). 
+  - Live, or code published if it is FOSS.
+- You must work directly on the project and have strong understanding of its
+  fundamentals. You should be prepared to answer technical questions about how
+  the project is implemented.
+- The presentation must be centered around a live demo. Anything more then 3-5
+  minutes of slides is not allowed without explicit approval.
+- Your presentation must be complete 1 week before the event. Be prepared to do
+  a dry run of your presentation with the BitDevs organization team.
+
+If you're interested in sharing your project with the BitDevs community we'd
+love to host you.
+
+-the BitDevs team

--- a/assets/css/_blog.scss
+++ b/assets/css/_blog.scss
@@ -1,0 +1,45 @@
+.Blog {
+  font-family: sans-serif;
+  // font-family: "Roboto",sans-serif;
+  word-wrap: break-word;
+  
+
+  em {font-style: italic}
+  strong {font-weight: bold}
+  ol, ul {
+    list-style: disc;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+  }
+  ul ul {
+    margin-block-start: 0px;
+    margin-block-end: 0px;
+  }
+  li:before {
+  content: initial
+  }
+
+  &-title {
+    margin: 0 0 0.25rem 0;
+    font-size: 1.8rem;
+  }
+
+  &-info {
+    display: flex;
+    font-size: 0.8rem;
+    opacity: 0.7;
+    margin-bottom: 2rem;
+
+    > * {
+      &:after {
+        content: '·';
+        margin: 0 0.5rem;
+        opacity: 0.5;
+      }
+
+      &:last-child:after {
+        display: none;
+      }
+    }
+  }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -21,3 +21,4 @@ $large-screen: 1024px;
 @import './footer';
 @import './home';
 @import './post';
+@import './blog';

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Blog Posts
+---
+
+<div class="Home">
+  <div class="Home-posts">
+    <h2 class="Home-posts-title">Blog Posts</h2>
+    {% for post in site.posts %}
+      {% if post.type == "blog" %}
+        <div class="Home-posts-post">
+          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
+          <span class="Home-posts-post-arrow">&raquo;</span>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+        </div>
+      {% endif %}
+    {% endfor %}
+</div>

--- a/events.html
+++ b/events.html
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Meetings
+---
+
+<div class="Home">
+  <div class="Home-posts">
+    <h2 class="Home-posts-title">Socratic Seminars</h2>
+    {% for post in site.posts %}
+      {% if post.type == "socratic" %}
+        <div class="Home-posts-post">
+          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
+          <span class="Home-posts-post-arrow">&raquo;</span>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+        </div>
+      {% endif %}
+    {% endfor %}
+    <h4 class="Home-posts-subtitle">Ethereum Socratic Seminars</h4>
+    {% for post in site.posts %}
+      {% if post.type == "ethereum_socratic" %}
+        <div class="Home-posts-post">
+          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
+          <span class="Home-posts-post-arrow">&raquo;</span>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+
+  <div class="Home-posts">
+    <h2 class="Home-posts-title">Whitepaper Series</h2>
+    {% for post in site.posts %}
+      {% if post.type == "whitepaper" %}
+        <div class="Home-posts-post">
+          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
+          &raquo;
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+</div>

--- a/index.html
+++ b/index.html
@@ -9,38 +9,41 @@ title: Home
   </p>
 
   <div class="Home-posts">
-    <h2 class="Home-posts-title">Socratic Seminars</h2>
+    <h2 class="Home-posts-title">Upcoming and Recent Events</h2>
+    {% assign event_posts = 7 %}
+    {% assign counter = 0 %}
     {% for post in site.posts %}
-      {% if post.type == "socratic" %}
+      {% if post.type == "socratic" or post.type == "whitepaper"%}
         <div class="Home-posts-post">
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
           <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
         </div>
+        {% assign counter = counter | plus: 1 %}
+        {% if counter == event_posts %}
+          {% break %} {% comment %}exit the for loop{% endcomment %}
+        {% endif %}
       {% endif %}
     {% endfor %}
-    <h4 class="Home-posts-subtitle">Ethereum Socratic Seminars</h4>
-    {% for post in site.posts %}
-      {% if post.type == "ethereum_socratic" %}
-        <div class="Home-posts-post">
-          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
-          <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
-        </div>
-      {% endif %}
-    {% endfor %}
+    <p><a href="/events.html">See all events</a></p>
   </div>
-
   <div class="Home-posts">
-    <h2 class="Home-posts-title">Whitepaper Series</h2>
+    <h2 class="Home-posts-title">Recent Blog Posts</h2>
+    {% assign blog_posts = 3 %}
+    {% assign counter = 0 %}
     {% for post in site.posts %}
-      {% if post.type == "whitepaper" %}
+      {% if post.type == "blog" %}
         <div class="Home-posts-post">
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           &raquo;
           <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
         </div>
+        {% assign counter = counter | plus: 1 %}
+        {% if counter == blog_posts %}
+          {% break %} {% comment %}exit the for loop{% endcomment %}
+        {% endif %}
       {% endif %}
     {% endfor %}
+    <p><a href="/blog.html">See all blog posts</a></p>
   </div>
 </div>


### PR DESCRIPTION
This takes the text from #48, slightly modifies the language to be friendlier, but still explicit in expectations.

The first commit adds `/blog` and `/events` pages, and then the second commit publishes *Presenter Guidelines* as a blog post. That means we have a stable URL to point people to for the guidelines (https://bitdevs.org/presenter-guidelines/) 