### PR TITLE
Add unpublished template for Socratic Newsletter

### DIFF
--- a/_posts/_template.md
+++ b/_posts/_template.md
@@ -11,8 +11,6 @@ meetup: "https://www.meetup.com/BitDevsNYC/"
 ## Announcements
 Please join us for our next Socratic Seminar. A special thank you to our sponsors [CardCoins](https://cardcoins.co), [Chaincode Labs](https://chaincode.com) and [Wolf NYC](https://wolfnyc.com) for food, refreshments and event space.
 
-We will be meeting at the Chaincode Labs office again! Please make sure you are RSVP'd, an identifier (but not a full name) is required for entry.
-
 If you can't make it to the main event please join us at PUBKEY around 9:30PM. **Learn about this awesome new establishment [here](https://ny.eater.com/2022/12/13/23494423/pubkey-opening-manhattan-bitcoin-bar).**
 
 ## Presentation
@@ -71,9 +69,6 @@ If you can't make it to the main event please join us at PUBKEY around 9:30PM. *
 ### [BOLTs](https://github.com/lightningnetwork/lightning-rfc)
 -
 
-### [BTCPay Server](https://github.com/btcpayserver/btcpayserver)
--
-
 ### [Bitcoin Core](https://github.com/bitcoin/bitcoin)
 -
 
@@ -83,13 +78,7 @@ If you can't make it to the main event please join us at PUBKEY around 9:30PM. *
 ### [HWI](https://github.com/bitcoin-core/HWI)
 -
 
-### [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver)
--
-
 ### [LDK](https://github.com/lightningdevkit/rust-lightning)
--
-
-### [Wasabi](https://github.com/zkSNACKs/WalletWasabi)
 -
 
 ### [dlcspecs](https://github.com/discreetlogcontracts/dlcspecs)

--- a/_posts/_template.md
+++ b/_posts/_template.md
@@ -1,0 +1,127 @@
+---
+layout: post
+published: false
+type: socratic
+title: "Socratic Seminar TODO"
+meetup: "https://www.meetup.com/BitDevsNYC/"
+---
+<!--- TODO: remove `published: false` when creating new socratic --->
+<!--- TODO: replace meetup link with https://www.meetup.com/BitDevsNYC/events/<##replace##>/ --->
+
+## Announcements
+Please join us for our next Socratic Seminar. A special thank you to our sponsors [CardCoins](https://cardcoins.co), [Chaincode Labs](https://chaincode.com) and [Wolf NYC](https://wolfnyc.com) for food, refreshments and event space.
+
+We will be meeting at the Chaincode Labs office again! Please make sure you are RSVP'd, an identifier (but not a full name) is required for entry.
+
+If you can't make it to the main event please join us at PUBKEY around 9:30PM. **Learn about this awesome new establishment [here](https://ny.eater.com/2022/12/13/23494423/pubkey-opening-manhattan-bitcoin-bar).**
+
+## Presentation
+-
+
+## Mailing Lists, Meetings and Bitcoin Optech
+### Mailing Lists
+#### [bitcoin-dev](https://lists.linuxfoundation.org/pipermail/bitcoin-dev)
+- <!--- TODO: https://lists.linuxfoundation.org/pipermail/bitcoin-dev --->
+
+#### [lightning-dev](https://lists.linuxfoundation.org/pipermail/lightning-dev)
+-
+
+#### [dlc-dev](https://mailmanlists.org/pipermail/dlc-dev)
+-
+
+### Meetings
+- [Bitcoin PR Review Club](https://bitcoincore.reviews)
+    - <!--- TODO replace: [25574 Improve error handling when VerifyDB fails due to insufficient dbcache (validation)](https://bitcoincore.reviews/25574) --->
+- Bitcoin Core general developer meetings
+	- <!--- TODO replace: [December 1st](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-01.html#255) --->
+- Bitcoin Core wallet meetings
+	- <!--- TODO replace: [December 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-02.html#313) --->
+- Lightning Specification meeting
+    - <!--- TODO replace: [December 5th](https://github.com/lightning/bolts/issues/1046) --->
+- Core Lightning Developer Call
+    - <!--- TODO replace: [September 20th](https://diyhpl.us/wiki/transcripts/c-lightning/2021-09-20-developer-call/) --->
+- dlc-specs meetings
+    - <!--- TODO replace: [October 5th](https://github.com/discreetlogcontracts/dlcspecs/pull/175) --->
+- Lightning specification meetings
+    - <!--- TODO replace: [October 11th](https://github.com/lightningnetwork/lightning-rfc/issues/920) --->
+
+### Optech
+- <!--- TODO replace: [Newsletter #229](https://bitcoinops.org/en/newsletters/2022/12/07/), [audio recap](https://twitter.com/bitcoinoptech/status/1600867081225764864) --->
+
+## Network Data
+-
+
+## CVEs and Research
+### Research
+-
+
+### InfoSec
+-
+
+## Pull Requests and repo updates
+### [BDK](https://github.com/bitcoindevkit/bdk)
+-
+
+### [BIPs](https://github.com/bitcoin/bips)
+-
+
+### [BLIPs](https://github.com/lightning/blips)
+-
+
+### [BOLTs](https://github.com/lightningnetwork/lightning-rfc)
+-
+
+### [BTCPay Server](https://github.com/btcpayserver/btcpayserver)
+-
+
+### [Bitcoin Core](https://github.com/bitcoin/bitcoin)
+-
+
+### [Core Lightning](https://github.com/ElementsProject/lightning)
+-
+
+### [HWI](https://github.com/bitcoin-core/HWI)
+-
+
+### [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver)
+-
+
+### [LDK](https://github.com/lightningdevkit/rust-lightning)
+-
+
+### [Wasabi](https://github.com/zkSNACKs/WalletWasabi)
+-
+
+### [dlcspecs](https://github.com/discreetlogcontracts/dlcspecs)
+-
+
+### [eclair](https://github.com/ACINQ/eclair/)
+-
+
+### [libsecp](https://github.com/bitcoin-core/secp256k1)
+-
+
+### [lnd](https://github.com/lightningnetwork/lnd)
+-
+
+### [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
+-
+
+### [secp256k1-zkp](https://github.com/ElementsProject/secp256k1-zkp)
+-
+
+
+## New Releases
+-
+
+## Events and Podcasts
+-
+
+## Mining
+-
+
+## Privacy
+-
+
+## Miscellaneous
+-


### PR DESCRIPTION
I concatenated all the headlines from the last few years of socratic meetings and added some useful links to look up content more quickly.

The template should be unpublished, so I figured keeping it in the `_posts` folder should work.