### PR TITLE
Fix broken jump to specific line for IRC links

### DIFF
--- a/_posts/2021-12-15-socratic-seminar-107.md
+++ b/_posts/2021-12-15-socratic-seminar-107.md
@@ -33,8 +33,8 @@ refreshments and event space.
 	- [23443 - Erlay support signaling](https://bitcoincore.reviews/23443)
 	- [23724 - add systemtap's sys/sdt.h as depends for GUIX builds with USDT tracepoints](https://bitcoincore.reviews/23724)
 - Bitcoin Core general developer meetings
-	- [December 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2021-12-02.html#435)
-	- [December 9th](https://www.erisian.com.au/bitcoin-core-dev/log-2021-12-09.html#518)
+	- [December 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2021-12-02.html#l-435)
+	- [December 9th](https://www.erisian.com.au/bitcoin-core-dev/log-2021-12-09.html#l-518)
 - c-lightning meetings
 	- [December 13th](https://btctranscripts.com/c-lightning/2021-12-13-developer-call/)
 - dlc-specs metings

--- a/_posts/2022-01-27-socratic-seminar-108.md
+++ b/_posts/2022-01-27-socratic-seminar-108.md
@@ -43,12 +43,12 @@ refreshments and event space.
     - [23201 Allow users to specify input weights when funding a transaction (wallet, rpc/rest/zmq)](https://bitcoincore.reviews/23201)
     - [24007 Allow tx replacement by smaller witness (tx fees and policy, validation)](https://bitcoincore.reviews/24007)
 - Bitcoin Core general developer meetings
-    - [December 16th](https://www.erisian.com.au/bitcoin-core-dev/log-2021-12-16.html#364)
-    - [January 6th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-01-06.html#295)
-    - [January 13th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-01-13.html#445)
-    - [January 20th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-01-20.html#297)
+    - [December 16th](https://www.erisian.com.au/bitcoin-core-dev/log-2021-12-16.html#l-346)
+    - [January 6th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-01-06.html#l-295)
+    - [January 13th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-01-13.html#l-445)
+    - [January 20th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-01-20.html#l-297)
 - Bitcoin Core wallet meetings
-    - [December 17th](https://www.erisian.com.au/bitcoin-core-dev/log-2021-12-17.html#418)
+    - [December 17th](https://www.erisian.com.au/bitcoin-core-dev/log-2021-12-17.html#l-418)
 - dlc-specs meetings
     - [January 11th](https://github.com/discreetlogcontracts/dlcspecs/pull/184)
 - Lightning specification meetings

--- a/_posts/2022-06-30-socratic-seminar-113.md
+++ b/_posts/2022-06-30-socratic-seminar-113.md
@@ -32,14 +32,14 @@ refreshments and event space.
     - [24832 Verify the block filter hash when reading the filter from disk. (utxo db and indexes)](https://bitcoincore.reviews/24832)
 
 - Bitcoin Core general developer meetings
-    - [June 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-02.html#293)
-    - [June 9th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-09.html#173)
-    - [June 16th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-16.html#382)
-    - [June 23rd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-23.html#291)
-    - [June 30th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-30.html#1)
+    - [June 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-02.html#l-293)
+    - [June 9th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-09.html#l-173)
+    - [June 16th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-16.html#l-382)
+    - [June 23rd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-23.html#l-291)
+    - [June 30th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-30.html#l-1)
 - Bitcoin Core wallet meetings
-    - [June 3rd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-03.html#184)
-    - [June 17th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-17.html#207)
+    - [June 3rd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-03.html#l-184)
+    - [June 17th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-06-17.html#l-207)
 - dlc-specs meetings
     - [June 8th](https://github.com/discreetlogcontracts/dlcspecs/pull/197)
 - Lightning specification meetings

--- a/_posts/2022-07-28-socratic-seminar-114.md
+++ b/_posts/2022-07-28-socratic-seminar-114.md
@@ -34,13 +34,13 @@ refreshments and event space.
     - [24858 incorrect blk file size calculation during reindex results in recoverable blk file corruption (block storage)](https://bitcoincore.reviews/24858)
 
 - Bitcoin Core general developer meetings
-    - [July 7th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-07.html#390)
-    - [July 14th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-14.html#247)
-    - [July 21th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-21.html#181)
-    - [July 28th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-28.html#276)
+    - [July 7th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-07.html#l-390)
+    - [July 14th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-14.html#l-247)
+    - [July 21th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-21.html#l-181)
+    - [July 28th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-28.html#l-276)
 - Bitcoin Core wallet meetings
-    - [July 1st](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-01.html#332)
-    - [July 15th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-01.html#259)
+    - [July 1st](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-01.html#l-332)
+    - [July 15th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-07-01.html#l-259)
 - dlc-specs meetings
     - [July 12th](https://github.com/discreetlogcontracts/dlcspecs/pull/198)
 - Lightning specification meetings

--- a/_posts/2022-12-15-socratic-seminar-119.md
+++ b/_posts/2022-12-15-socratic-seminar-119.md
@@ -38,10 +38,10 @@ If you can't make it to the main event please join us at PUBKEY around 9:30PM. *
     - [25574 Improve error handling when VerifyDB fails due to insufficient dbcache (validation)](https://bitcoincore.reviews/25574)
     - [26631 add coverage for dust mempool policy (-dustrelayfee setting) (tests)](https://bitcoincore.reviews/26631)
 - Bitcoin Core general developer meetings
-	- [December 1st](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-01.html#255)
-	- [December 8th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-08.html#206)
+	- [December 1st](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-01.html#l-255)
+	- [December 8th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-08.html#l-206)
 - Bitcoin Core wallet meetings
-	- [December 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-02.html#313)
+	- [December 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-02.html#l-313)
 - Lightning Specification meeting
     - [December 5th](https://github.com/lightning/bolts/issues/1046)
 

--- a/_posts/2023-01-26-socratic-seminar-120.md
+++ b/_posts/2023-01-26-socratic-seminar-120.md
@@ -41,15 +41,15 @@ If you can’t make it to the main event please join us at PUBKEY around 9:30PM.
     - [26697 logging: use std::bitset for categories (utils/log/libs)](https://bitcoincore.reviews/26697)
     - [26347 wallet: ensure the wallet is unlocked when needed for rescanning (wallet)](https://bitcoincore.reviews/26347)
 - Bitcoin Core general developer meetings
-	- [December 15th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-15.html#197)
-	- [December 22nd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-15.html#206)
-	- [January 5th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-05.html#115)
-	- [January 12th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-12.html#314)
-	- [January 19th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-19.html#337)
-	- [January 26th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-26.html#337)
+	- [December 15th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-15.html#l-197)
+	- [December 22nd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-15.html#l-206)
+	- [January 5th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-05.html#l-115)
+	- [January 12th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-12.html#l-314)
+	- [January 19th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-19.html#l-337)
+	- [January 26th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-26.html#l-337)
 - Bitcoin Core wallet meetings
-	- [December 16th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-16.html#281)
-	- [January 13th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-13.html#404)
+	- [December 16th](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-16.html#l-281)
+	- [January 13th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-13.html#l-404)
 - Lightning Specification meeting
     - [December 19th](https://github.com/lightning/bolts/issues/1047)
     - [January 2nd](https://github.com/lightning/bolts/issues/1048)

--- a/_posts/2023-02-23-socratic-seminar-121.md
+++ b/_posts/2023-02-23-socratic-seminar-121.md
@@ -33,12 +33,12 @@ If you can't make it to the main event please join us at PUBKEY around 9:30PM. *
     - [26441 add `addpermissionflags` RPC (rpc, p2p) ](https://bitcoincore.reviews/26441)
     - [25038 nVersion=3 and Package RBF (tx fees and policy)](https://bitcoincore.reviews/25038)
 - Bitcoin Core general developer meetings
-    - [February 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2023-02-02.html#291)
-    - [February 9th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-02-09.html#246)
-    - [February 16th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-02-16.html#175)
+    - [February 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2023-02-02.html#l-291)
+    - [February 9th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-02-09.html#l-246)
+    - [February 16th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-02-16.html#l-175)
 - Bitcoin Core wallet meetings
-    - [January 27th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-27.html#387)
-    - [February 10th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-02-10.html#182)
+    - [January 27th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-01-27.html#l-387)
+    - [February 10th](https://www.erisian.com.au/bitcoin-core-dev/log-2023-02-10.html#l-182)
 - Lightning Specification meeting
     - [January 30th](https://github.com/lightning/bolts/issues/1053)
     - [February 13th](https://github.com/lightning/bolts/issues/1055)

--- a/_posts/_template.md
+++ b/_posts/_template.md
@@ -31,9 +31,9 @@ If you can't make it to the main event please join us at PUBKEY around 9:30PM. *
 - [Bitcoin PR Review Club](https://bitcoincore.reviews)
     - <!--- TODO replace: [25574 Improve error handling when VerifyDB fails due to insufficient dbcache (validation)](https://bitcoincore.reviews/25574) --->
 - Bitcoin Core general developer meetings
-	- <!--- TODO replace: [December 1st](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-01.html#255) --->
+	- <!--- TODO replace: [December 1st](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-01.html#l-255) --->
 - Bitcoin Core wallet meetings
-	- <!--- TODO replace: [December 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-02.html#313) --->
+	- <!--- TODO replace: [December 2nd](https://www.erisian.com.au/bitcoin-core-dev/log-2022-12-02.html#l-313) --->
 - Lightning Specification meeting
     - <!--- TODO replace: [December 5th](https://github.com/lightning/bolts/issues/1046) --->
 - Core Lightning Developer Call


### PR DESCRIPTION
I just put in the links for the Core Dev meetings and noticed that they would not jump to the correct line. Fixing this issue for the template and past instances where it was also broken.