### PR TITLE
Bitcoin 2025 Socratic Seminar

### DIFF
--- a/_posts/2025-05-28-bitcoin-2025-socratic-seminar.md
+++ b/_posts/2025-05-28-bitcoin-2025-socratic-seminar.md
@@ -1,0 +1,31 @@
+---
+layout: post
+type: socratic
+title: "Bitcoin 2025 Socratic Seminar"
+meetup: "https://b.tc/conference/2025/"
+---
+
+## Announcements
+Please join us for a special Socratic Seminar at Bitcoin 2025 in Las Vegas, NV. This will be on Wednesday at 3:30PM Pacific time at the Open Source Stage.
+
+## Housekeeping
+
+- Chatham house rules are in effect at this event. Please no photos or videos. If you talk about what was discussed at the event, please do not identify participants in the discussion.
+- What is [BitDevs](https://bitdevs.org/about)?
+- [Start your own BitDevs!](https://bitdevs.org/cities)
+
+### Matt
+
+### Murch
+
+### Stephen
+
+- [Bitcoin and Quantum Computing: Current Status and Future Directions](https://chaincode.com/bitcoin-post-quantum.pdf)
+- [CakeWallet ads PayJoin V2 support](https://x.com/cakewallet/status/1924594310202155069)
+- [BOLT 12 - re-add recurrence support](https://github.com/lightning/bolts/pull/1240)
+- [Breez Nodeless supports BOLT12 and BIP353](https://x.com/Breez_Tech/status/1925190330426499554)
+- [Continued discussion around BIP177 - Redefine Bitcoin's base unit](https://github.com/bitcoin/bips/blob/master/bip-0177.mediawiki)
+- [A Zero-Dependency Web Component for Stylish BIP-21 Payments](https://stacker.news/items/893417)
+- [DMND Stratum V2 Mining Pool emerges from stealth](https://x.com/DEMAND_POOL/status/1902054071940370540)
+- [Coin Control UI for Bitcoin Core App - PR](https://github.com/BitcoinDesign/Bitcoin-Core-App/pull/154) - [Issue](https://github.com/BitcoinDesign/Bitcoin-Core-App/issues/153)
+- [descriptor-encrypt: a rust library to encrypt Bitcoin descriptors](https://github.com/joshdoman/descriptor-encrypt)


### PR DESCRIPTION
We're hosting a Socratic Seminar at Bitcoin 2025. Obviously this is the NYC meetup, but it's also the main bitdevs.org website with all the great info about the other cities meetups. So it felt fitting to me for this content to live here, similar to how other conference BitDevs meetups live there.