### PR TITLE
Change Sydney bitdevs

### DIFF
--- a/cities.md
+++ b/cities.md
@@ -46,7 +46,7 @@ As a disclaimer, BitDevs NYC has no official associations with or oversight of t
 - [São Paulo](https://bitdevsportugues.org)
 - [Seattle](https://github.com/reardencode/seattle_bitdevs)
 - [Singapore](https://bitdevs.sg/)
-- [Sydney](https://www.meetup.com/bitcoin_sydney/)
+- [Sydney](https://sydney.bitdevs.com.au/)
 - [Taipei](https://bitdevs.tw/)
 - [Tampa](https://tampabitdevs.io/)
 - [Vancouver](https://bitdevs.ca/)


### PR DESCRIPTION
Sydney now has a bitdevs meet separate to the regular meetup. Its a subset of the same crew and there are good relations between everyone involved.

Seeing as this is the bitdevs page not the Bitcoin Meetups page link to the Sydney bitdevs website instead of meetup.com where the Sydney Bitcoin organises themselves.