### PR TITLE
Added Bitdevs Mauritius

### DIFF
--- a/cities.md
+++ b/cities.md
@@ -33,6 +33,7 @@ As a disclaimer, BitDevs NYC has no official associations with or oversight of t
 - [Los Angeles](https://bitdevsla.org/)
 - [Louisville](https://loubitdevs.org/)
 - [Lusaka](https://BitDevsZambia.org/)
+- [Mauritius](https://bitdevsmauritius.org/)
 - [Melbourne](https://melb.bitdevs.com.au/)
 - [Mexico City](https://cdmxbitdevs.org)
 - [Miami](https://miamibitdevs.org/)


### PR DESCRIPTION
BitDevs Mauritius started last year in November, and since then it has been steadily growing into a focused technical community for Bitcoin builders, researchers, and open-source contributors in Mauritius.