### PR TITLE
Isolate NYC and add Luma links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ sass:
   style: :compressed
 
 # Customise atom feed settings (this is where Jekyll-Feed gets configuration information)
-title: "BitDevs NYC"
+title: "BitDevs"
 description: "BitDevs is a community for those interested in discussing and participating in the research and development of Bitcoin and related protocols."
 
 # Leave out some files

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -1,9 +1,13 @@
-title: 'BitDevs NYC'
+title: 'BitDevs'
 tagline: 'BitDevs is a community for those interested in discussing and participating in the research and development of Bitcoin and related protocols.'
 
 menu:
   - {name: 'About', url: '/about'}
-  - {name: 'Events', url: '/events'}
   - {name: 'Blog', url: '/blog'}
-  - {name: 'Meetup', url: 'https://www.meetup.com/BitDevsNYC/', external: true}
   - {name: 'Cities', url: '/cities'}
+  - name: 'New York City'
+    submenu:
+      - {name: 'Events', url: '/events'}
+      - {name: 'Meetup', url: 'https://www.meetup.com/BitDevsNYC/', external: true}
+      - {name: 'Luma', url: 'https://luma.com/calendar/cal-BocajELvgRuxaCx', external: true}
+  

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,20 @@
     </div>
     <nav class="Header-nav">
       {% for item in site.data.settings.menu %}
-        {% if item.external %}
+        {% if item.submenu %}
+        <details class="Header-dropdown">
+          <summary class="Header-dropdown-label">{{ item.name }}</summary>
+          <div class="Header-dropdown-menu">
+            {% for sub in item.submenu %}
+              {% if sub.external %}
+              <a href="{{ sub.url }}" target="_blank" rel="noopener nofollow">{{ sub.name }}</a>
+              {% else %}
+              <a href="{{ site.github.url }}{{ sub.url }}">{{ sub.name }}</a>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </details>
+        {% elsif item.external %}
         <a href="{{ item.url }}" target="_blank" rel="noopener nofollow">
             {{ item.name }}
         </a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,10 +7,18 @@ layout: default
     <h1 class="Post-title">{{ page.title }}</h1>
     <div class="Post-info">
       <span>{{ page.date | date_to_string }}</span>
+      <span>Links for this event:</span>
       {% if page.meetup %}
         <span>
           <a href="{{ page.meetup }}" target="_blank" rel="noopener nofollow">
-            Link to Meetup
+            Meetup
+          </a>
+        </span>
+      {% endif %}
+      {% if page.luma %}
+        <span>
+          <a href="{{ page.luma }}" target="_blank" rel="noopener nofollow">
+            Luma
           </a>
         </span>
       {% endif %}

--- a/_posts/2026-08-27-socratic-seminar-161.md
+++ b/_posts/2026-08-27-socratic-seminar-161.md
@@ -3,6 +3,7 @@ layout: post
 type: socratic
 title: "Socratic Seminar 161"
 meetup: "https://www.meetup.com/bitdevsnyc/events/315764508/"
+luma: "https://luma.com/g8341lqj"
 ---
 
 ## Announcements

--- a/assets/css/_header.scss
+++ b/assets/css/_header.scss
@@ -25,6 +25,7 @@
   &-nav {
     display: flex;
     font-size: 1.3rem;
+    align-items: center;
 
     @media (max-width: $small-screen) {
       font-size: 1.1rem;
@@ -39,6 +40,59 @@
         color: $primary-color;
         opacity: 1;
       }
+    }
+  }
+
+  &-dropdown {
+    position: relative;
+    margin-left: 1.5rem;
+
+    &-label {
+      color: #333;
+      opacity: 0.4;
+      cursor: pointer;
+      list-style: none;
+
+      &::-webkit-details-marker { display: none; }
+
+      &::after {
+        content: ' ▾';
+        font-size: 0.8em;
+      }
+    }
+
+    &[open] &-label,
+    &:hover &-label {
+      color: $primary-color;
+      opacity: 1;
+    }
+
+    &-menu {
+      display: none;
+      position: absolute;
+      top: 100%;
+      right: 0;
+      background-color: $background-color;
+      border: 1px solid rgba(#333, 0.2);
+      padding: 0.4rem 0;
+      white-space: nowrap;
+      z-index: 100;
+
+      a {
+        display: block;
+        margin: 0;
+        padding: 0.3rem 1rem;
+        opacity: 0.4;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+    }
+
+    &[open] &-menu,
+    &:hover &-menu {
+      display: block;
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: Home
   </p>
 
   <div class="Home-posts">
-    <h2 class="Home-posts-title">Upcoming and Recent Events</h2>
+    <h2 class="Home-posts-title">Upcoming and Recent Events in New York City:</h2>
     {% assign event_posts = 7 %}
     {% assign counter = 0 %}
     {% for post in site.posts %}


### PR DESCRIPTION
<img width="848" height="199" alt="Screenshot 2026-07-22 at 9 57 12 AM" src="https://github.com/user-attachments/assets/cb629221-69d8-4056-b002-2413f431e328" />


<img width="375" height="667" alt="ios-screenshot" src="https://github.com/user-attachments/assets/c14511d1-ff85-400d-b6cd-cf0fde5d93c4" />



- "BitDevs NYC" -> "BitDevs" in the headline
- Add links to parallel calendar on Luma
- Put events and meetup (and luma) which were all NY-specific in a New York menu


(written with Claude)